### PR TITLE
Fix bug in role caching and RP request command

### DIFF
--- a/modules/admin.py
+++ b/modules/admin.py
@@ -191,7 +191,7 @@ class Admin(AbstractCog, name="Админ-команды"):
     @app_commands.checks.cooldown(1, 30, key=lambda interaction: interaction.user.id)
     @app_commands.guild_only()
     @app_commands.check(AbstractCog.reconnect)
-    async def add_tech_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
+    async def add_rp_request_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         bot: Katherine = interaction.client  # noqa
 
         await interaction.response.send_message("***Ожидайте...***")

--- a/utils/context.py
+++ b/utils/context.py
@@ -100,10 +100,10 @@ class Context(commands.Context):
 
             if guild.admin_role:
                 self.administrator_role: discord.Role = self.guild.get_role(int(guild.admin_role))
-                values['admin_role_id'] = self.admin_role.id
+                values['admin_role_id'] = self.administrator_role.id
             else:
                 self.administrator_role: discord.Role = self.guild.roles[-1]
-                values['admin_role_id'] = self.admin_role.id
+                values['admin_role_id'] = self.administrator_role.id
 
             if guild.operator_role:
                 self.op_role: discord.Role = self.guild.get_role(int(guild.operator_role))


### PR DESCRIPTION
## Summary
- fix attribute name when storing admin role in cache
- rename duplicate `add_tech_channel` method to `add_rp_request_channel`

## Testing
- `python -m py_compile utils/context.py modules/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_684872f44298832bb957e662014166d3